### PR TITLE
Clean views and remove duplicate Bootstrap imports

### DIFF
--- a/app/views/Statistique/Stat.php
+++ b/app/views/Statistique/Stat.php
@@ -1,21 +1,10 @@
-<!DOCTYPE html>
-<html lang="fr">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Statistiques Produits</title>
+<!-- Chart.js -->
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<!-- Font Awesome -->
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+<!-- CSS personnalisé pour les statistiques -->
+<link rel="stylesheet" href="/assets/css/stat.css">
 
-    <!-- Chart.js -->
-    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-    <!-- Bootstrap 5 -->
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
-    <!-- Font Awesome -->
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-    <!-- CSS personnalisé pour les statistiques -->
-    <link rel="stylesheet" href="/assets/css/stat.css">
-</head>
-
-<body>
 <div class="dashboard-container">
     <div class="card">
         <!-- Entête -->
@@ -184,9 +173,3 @@
         </div>
     </div>
 </div>
-
-<!-- Bootstrap JS -->
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-
-</body>
-</html>

--- a/app/views/Statistique/StatRecette.php
+++ b/app/views/Statistique/StatRecette.php
@@ -1,23 +1,11 @@
-<!DOCTYPE html>
-<html lang="fr">
+<!-- Font Awesome -->
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+<!-- Chart.js -->
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<!-- CSS personnalisé -->
+<link rel="stylesheet" href="/assets/css/stat.css">
 
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Statistiques de vente</title>
-
-    <!-- Bootstrap CSS -->
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
-    <!-- Font Awesome -->
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-    <!-- Chart.js -->
-    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-    <!-- CSS personnalisé -->
-    <link rel="stylesheet" href="/assets/css/stat.css">
-</head>
-
-<body>
-    <div class="container">
+<div class="container">
         <h1><i class="fas fa-chart-line me-3"></i>Statistiques de vente</h1>
 
         <!-- Filtres -->
@@ -222,8 +210,6 @@
         </div>
     </div>
 
-    <!-- Bootstrap JS -->
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"></script>
     <script>
         // Script Chart.js inchangé
         document.addEventListener('DOMContentLoaded', function() {
@@ -277,8 +263,5 @@
                     }
                 }
             });
-        });
-    </script>
-</body>
-
-</html>
+        });    </script>
+</div>

--- a/app/views/Statistique/benefice.php
+++ b/app/views/Statistique/benefice.php
@@ -1,16 +1,6 @@
-<!DOCTYPE html>
-<html lang="fr">
+<link rel="stylesheet" href="/assets/css/benef.css">
 
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Calcul du Bénéfice</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
-    <link rel="stylesheet" href="/assets/css/benef.css">
-</head>
-
-<body>
-    <div class="container">
+<div class="container">
         <h2>Calcul du bénéfice</h2>
 
         <div class="form-container">
@@ -238,7 +228,3 @@
         <?php endif; ?>
 
     </div>
-
-</body>
-
-</html>

--- a/app/views/admin/crud_branche.php
+++ b/app/views/admin/crud_branche.php
@@ -1,11 +1,4 @@
-<!DOCTYPE html>
-<html lang="fr">
-<head>
-    <meta charset="UTF-8">
-    <title>Gestion des Branches</title>
-    <link rel="stylesheet" href="/assets/css/crud.css">
-</head>
-<body>
+<link rel="stylesheet" href="/assets/css/crud.css">
 
 <div class="container">
     <h1>Gestion des Branches</h1>
@@ -92,5 +85,3 @@ function toggleEdit(button) {
 }
 </script>
 
-</body>
-</html>

--- a/app/views/admin/crud_categorie.php
+++ b/app/views/admin/crud_categorie.php
@@ -1,12 +1,5 @@
-<!DOCTYPE html>
-<html lang="fr">
-<head>
-    <meta charset="UTF-8">
-    <title>Gestion des Catégories</title>
-    <link rel="stylesheet" href="/assets/css/crud.css">
+<link rel="stylesheet" href="/assets/css/crud.css">
 
-</head>
-<body>
 <div class="container">
     <h1>Gestion des Catégories</h1>
 
@@ -100,5 +93,3 @@ function toggleEdit(button) {
 }
 </script>
 
-</body>
-</html>

--- a/app/views/admin/crud_marque.php
+++ b/app/views/admin/crud_marque.php
@@ -1,11 +1,5 @@
-<!DOCTYPE html>
-<html lang="fr">
-<head>
-    <meta charset="UTF-8">
-    <title>Gestion des Marques</title>
-    <link rel="stylesheet" href="/assets/css/crud.css">
-</head>
-<body>
+<link rel="stylesheet" href="/assets/css/crud.css">
+
 <div class="container">
     <h1>Gestion des Marques</h1>
 
@@ -87,5 +81,3 @@ function toggleEdit(button) {
 }
 </script>
 
-</body>
-</html>

--- a/app/views/admin/crud_produit.php
+++ b/app/views/admin/crud_produit.php
@@ -1,11 +1,4 @@
-<!DOCTYPE html>
-<html lang="fr">
-<head>
-    <meta charset="UTF-8">
-    <title>Gestion des Produits</title>
-    <link rel="stylesheet" href="/assets/css/crud.css">
-</head>
-<body>
+<link rel="stylesheet" href="/assets/css/crud.css">
 
 <div class="container">
     <h1>Gestion des Produits</h1>
@@ -125,5 +118,3 @@ function toggleEdit(button) {
 }
 </script>
 
-</body>
-</html>

--- a/app/views/admin/crud_service.php
+++ b/app/views/admin/crud_service.php
@@ -1,11 +1,4 @@
-<!DOCTYPE html>
-<html lang="fr">
-<head>
-    <meta charset="UTF-8">
-    <title>Gestion des Services</title>
-    <link rel="stylesheet" href="/assets/css/crud.css">
-</head>
-<body>
+<link rel="stylesheet" href="/assets/css/crud.css">
 
 <div class="container">
     <h1>Gestion des Services</h1>
@@ -108,5 +101,3 @@ function toggleEdit(button) {
 }
 </script>
 
-</body>
-</html>

--- a/app/views/admin/crud_stock.php
+++ b/app/views/admin/crud_stock.php
@@ -1,13 +1,6 @@
-<!DOCTYPE html>
-<html lang="fr">
+<link rel="stylesheet" href="/assets/css/crud.css">
 
-<head>
-    <meta charset="UTF-8">
-    <title>Gestion des Stocks</title>
-    <link rel="stylesheet" href="/assets/css/crud.css">
-</head>
-
-<body>
+    <div class="container">
 
     <div class="container">
         <h1>Gestion des Stocks</h1>
@@ -59,7 +52,3 @@
             </tbody>
         </table>
     </div>
-
-</body>
-
-</html>

--- a/app/views/admin/crud_type_mouvement.php
+++ b/app/views/admin/crud_type_mouvement.php
@@ -1,11 +1,4 @@
-<!DOCTYPE html>
-<html lang="fr">
-<head>
-    <meta charset="UTF-8">
-    <title>Gestion des Types de Mouvement</title>
-    <link rel="stylesheet" href="/assets/css/crud.css">
-</head>
-<body>
+<link rel="stylesheet" href="/assets/css/crud.css">
 
 <div class="container">
     <h1>Gestion des Types de Mouvement</h1>
@@ -92,5 +85,3 @@ function toggleEdit(button) {
 }
 </script>
 
-</body>
-</html>

--- a/app/views/connexion/avec_poste/accueil.php
+++ b/app/views/connexion/avec_poste/accueil.php
@@ -1,23 +1,11 @@
-<!DOCTYPE html>
-<html lang="fr">
-
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Gestion des PC</title>
-
-    <!-- Bootstrap CSS -->
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
-    <!-- Bootstrap Icons -->
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css" rel="stylesheet">
+<!-- Bootstrap Icons -->
+<link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css" rel="stylesheet">
 
     <!-- CSS de Select2 -->
     <link href="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css" rel="stylesheet" />
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/select2-bootstrap-5-theme@1.3.0/dist/select2-bootstrap-5-theme.min.css" />
     <link rel="stylesheet" href="/assets/css/connexion/style_accueil.css">
-</head>
 
-<body>
 
     <div class="main-content">
         <div class="pc-management">
@@ -197,10 +185,5 @@
         </div>
     </div>
 
-    <!-- <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script> -->
     <script src="/assets/js/script.js"></script>
     <script src="/assets/js/automatisation.js"></script>
-
-</body>
-
-</html>

--- a/app/views/connexion/historique/Histo_Connexion.php
+++ b/app/views/connexion/historique/Histo_Connexion.php
@@ -1,15 +1,4 @@
-<!DOCTYPE html>
-<html lang="fr">
-
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Historique des Connexions</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
-</head>
-
-<body>
-    <div class="container mt-4">
+<div class="container mt-4">
         <h1 class="mb-4">Historique des Connexions</h1>
 
         <!-- Filtres -->
@@ -108,8 +97,4 @@
             </div>
         </div>
     </div>
-
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"></script>
-</body>
-
-</html>
+</div>

--- a/app/views/connexion/historique/etat.php
+++ b/app/views/connexion/historique/etat.php
@@ -1,14 +1,1 @@
-<!DOCTYPE html>
-<html lang="en">
-
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Document</title>
-</head>
-
-<body>
-    <?php echo var_dump($erreur); ?>
-</body>
-
-</html>
+<?php echo var_dump($erreur); ?>

--- a/app/views/connexion/historique/index.php
+++ b/app/views/connexion/historique/index.php
@@ -1,16 +1,4 @@
-<!DOCTYPE html>
-<html lang="fr">
-
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Payement des connexions</title>
-    <!-- Bootstrap CSS from CDN -->
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
-</head>
-
-<body>
-    <div class="container mt-4">
+<div class="container mt-4">
         <h2>Payement des connexions</h2>
         <table class="table table-bordered table-striped mt-3">
             <thead class="table-light">
@@ -58,8 +46,4 @@
             </tbody>
         </table>
     </div>
-
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-</body>
-
-</html>
+</div>

--- a/app/views/connexion/sans_poste/index.php
+++ b/app/views/connexion/sans_poste/index.php
@@ -1,21 +1,10 @@
-<!DOCTYPE html>
-<html lang="fr">
+<!-- Font Awesome -->
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+<!-- Select2 CSS -->
+<link href="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css" rel="stylesheet">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/select2-bootstrap-5-theme@1.3.0/dist/select2-bootstrap-5-theme.min.css">
 
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Gestion WiFi - Connexion Clients</title>
-    <!-- Bootstrap CSS -->
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
-    <!-- Font Awesome -->
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-    <!-- Select2 CSS -->
-    <link href="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/select2-bootstrap-5-theme@1.3.0/dist/select2-bootstrap-5-theme.min.css">
-</head>
-
-<body class="bg-light">
-    <div class="container-fluid py-4">
+<div class="container-fluid py-4">
         <!-- En-tête -->
         <div class="row mb-4">
             <div class="col-12">
@@ -160,8 +149,6 @@
 
         <?php include('modal.php') ?>
 
-        <!-- Bootstrap JS Bundle with Popper -->
-        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 
         <script>
             // Fonction pour calculer et afficher la durée
@@ -282,7 +269,3 @@
                 });
             });
         </script>
-
-</body>
-
-</html>


### PR DESCRIPTION
## Summary
- drop standalone HTML wrappers in admin and stats subviews
- keep page-specific styles in each subview
- remove duplicate Bootstrap includes from connexion views
- simplify debugging view

## Testing
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686d494af5508331abfa406cca6c2aab